### PR TITLE
use only 63 MB for boot

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -31,7 +31,7 @@ PARTITION=false
 PARTITION_NEEDED=false
 FORMAT=false
 
-SIZE_P1=512   # exact size of the partition 1 (boot) in MB
+SIZE_P1=63    # exact size of the partition 1 (boot) in MB
 SIZE_P2=2048  # exact size of the partition 2 (system) in MB
 SIZE_P3=512   # exact size of the partition 3 (cache) in MB
 SIZE_P4=1024  # minimum size of the partition 4 (userdata) in MB


### PR DESCRIPTION
I was able to get it to work on a Raspberry Pi Compute Module, which only has 3728 MiB by shrinking the boot file system to the same size as on Raspbian.